### PR TITLE
Closing the InteractiveSession opened at Line 207

### DIFF
--- a/deep_q_network.py
+++ b/deep_q_network.py
@@ -207,6 +207,7 @@ def playGame():
     sess = tf.InteractiveSession()
     s, readout, h_fc1 = createNetwork()
     trainNetwork(s, readout, h_fc1, sess)
+    sess.close()
 
 def main():
     playGame()


### PR DESCRIPTION
The InteractiveSession started at Line 207 is never closed. This pull request closes the InteractiveSession at Line 209 as the sess variable is no longer used after that.